### PR TITLE
ユーザーDB作成・追加・編集

### DIFF
--- a/src/components/GithubAuth.vue
+++ b/src/components/GithubAuth.vue
@@ -44,6 +44,14 @@ export default {
   created() {
     firebase.auth().onAuthStateChanged(user => {
       this.user = user ? user : {}
+
+      if (user != null) {
+          console.log("Login : " + user.displayName);
+          console.log("Login : " + user.uid);
+          if (user.displayName != "") {
+            this.$router.push({ name : "user", params: { uid: user.uid}})
+          }
+      }
     })
   },
   methods: {

--- a/src/components/GithubAuth.vue
+++ b/src/components/GithubAuth.vue
@@ -45,7 +45,7 @@ export default {
   },
   created() {
     console.log('Start GithubAuth...');
-    let self = this
+    let self = this;
 
     firebase.auth().onAuthStateChanged(user => {
 
@@ -56,7 +56,7 @@ export default {
           db.collection('users')
             .doc(user.uid)
             .get()
-            .then(function(dbUser) {
+            .then(dbUser => {
               if (dbUser.exists) {
                 console.log('Successfully fetched user data');
                 // console.log(JSON.stringify(dbUser.data()));
@@ -67,7 +67,7 @@ export default {
                 db.collection('users')
                   .doc(user.uid)
                   .set({
-                    name: user.displayName ? user.displayName : 'ななっしー',
+                    name: user.displayName || 'ななっしー',
                     photoURL: user.photoURL
                   })
                   .then(() => {
@@ -76,12 +76,11 @@ export default {
                     db.collection('users')
                       .doc(user.uid)
                       .get()
-                      .then(function(dbUser) {
+                      .then(dbUser => {
                         console.log('Successfully fetched user data');
                         // console.log(JSON.stringify(dbUser.data()));
                         self.user = dbUser.data();
                       });
-
                   })
                   .catch(err => {
                     console.error('Error Creating new user: ', err);
@@ -92,7 +91,7 @@ export default {
               console.error('Error fetching user data: ', err);
             });
       } else {
-        self.user = {}
+        self.user = {};
       }
     })
   },

--- a/src/components/GithubAuth.vue
+++ b/src/components/GithubAuth.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="github-auth">
     <h1>{{ msg }}</h1>
-    <div v-if="user.uid" key="login">
+    <div v-if="user.name" key="login">
       <img :src="user.photoURL"/><br>
-      [{{ user.displayName }}]<br>
+      <button @click="goMyPage">[{{ user.name }}](go to MyPage)</button><br>
       <v-btn class="ma-2"
              style="text-transform: none"
              color="black"
@@ -30,6 +30,8 @@
 
 <script>
 import firebase from 'firebase'
+import { db } from '@/firebase/firestore.js'
+
 export default {
   name: 'GithubAuth',
   props: {
@@ -42,20 +44,61 @@ export default {
     }
   },
   created() {
+    console.log('Start GithubAuth...');
+    let self = this
+
     firebase.auth().onAuthStateChanged(user => {
-      this.user = user ? user : {}
 
       if (user != null) {
-          console.log("Login : " + user.displayName);
-          if (user.displayName != "") {
-            this.$router.push({ name : "user", params: { uid: user.uid}})
-          }
+          console.log('Successfully Login');
+          // console.log(JSON.stringify(user));
+
+          db.collection('users')
+            .doc(user.uid)
+            .get()
+            .then(function(dbUser) {
+              if (dbUser.exists) {
+                console.log('Successfully fetched user data');
+                // console.log(JSON.stringify(dbUser.data()));
+                self.user = dbUser.data();
+              } else {
+                console.log('Creating user data...');
+
+                db.collection('users')
+                  .doc(user.uid)
+                  .set({
+                    name: user.displayName ? user.displayName : 'ななっしー',
+                    photoURL: user.photoURL
+                  })
+                  .then(() => {
+                    console.log('Successfully created new user');
+                    // console.log(JSON.stringify(user));
+                    db.collection('users')
+                      .doc(user.uid)
+                      .get()
+                      .then(function(dbUser) {
+                        console.log('Successfully fetched user data');
+                        // console.log(JSON.stringify(dbUser.data()));
+                        self.user = dbUser.data();
+                      });
+
+                  })
+                  .catch(err => {
+                    console.error('Error Creating new user: ', err);
+                  });
+              }
+            })
+            .catch(err => {
+              console.error('Error fetching user data: ', err);
+            });
+      } else {
+        self.user = {}
       }
     })
   },
   methods: {
     doLogin() {
-      console.log("doLogin");
+      console.log('doLogin');
       this.loggingIn = true;
       const provider = new firebase.auth.GithubAuthProvider();
       firebase.auth().signInWithPopup(provider)
@@ -64,8 +107,16 @@ export default {
                      });
     },
     doLogout() {
-      console.log("doLogout");
-      firebase.auth().signOut()
+      console.log('doLogout');
+      firebase.auth().signOut();
+    },
+    goMyPage() {
+      console.log('goMyPage');
+      firebase.auth().onAuthStateChanged(user => {
+        if (user != null) {
+          this.$router.push({ name : "user", params: { uid: user.uid}});
+        }
+      });
     }
   }
 }

--- a/src/components/GithubAuth.vue
+++ b/src/components/GithubAuth.vue
@@ -47,7 +47,6 @@ export default {
 
       if (user != null) {
           console.log("Login : " + user.displayName);
-          console.log("Login : " + user.uid);
           if (user.displayName != "") {
             this.$router.push({ name : "user", params: { uid: user.uid}})
           }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Home from '@/views/Home.vue'
 import Events from '@/views/Events.vue'
+import User from '@/views/User.vue'
 
 Vue.use(VueRouter)
 
@@ -16,6 +17,11 @@ const routes = [
     name: 'Events',
     component: Events
   },
+  {
+      path: '/user/:uid/',
+      name: 'user',
+      component: User
+    }
 ]
 
 const router = new VueRouter({

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -20,17 +20,20 @@
           </v-expansion-panel-header>
           <v-expansion-panel-content>
             <v-card class="pa-4 ma-6">
-              <v-card-text>
-                <v-text-field
-                  v-model="name"
-                  label="Name" />
-                <v-btn
-                  color="blue"
-                  :x-large="true"
-                  @click="update">
-                  Update
-                </v-btn>
-              </v-card-text>
+              <v-form v-model="isValid">
+                <v-card-text>
+                  <v-text-field
+                    v-model="name"
+                    label="Name"
+                    :rules="[requiredNotEmpty]" />
+                  <v-btn
+                    color="blue"
+                    :x-large="true"
+                    @click="update">
+                    Update
+                  </v-btn>
+                </v-card-text>
+              </v-form>
             </v-card>
           </v-expansion-panel-content>
         </v-expansion-panel>
@@ -50,7 +53,8 @@
       return {
         user: {},
         current: false,
-        name: ""
+        name: "",
+        isValid: false
       }
     },
     created() {
@@ -88,19 +92,28 @@
     methods: {
       update() {
         console.log('update...');
-
-        db.collection('users')
-          .doc(this.$route.params['uid'])
-          .update({
-            name: this.name || "ななっしー"
-          })
-          .then(() => {
-            console.log(`User ${this.name} was updated.`);
-            this.$router.go(this.$router.currentRoute);
-          })
-          .catch(err => {
-            console.error(`Error occurd in update: ${err}`);
-          });
+        if (this.isValid) {
+          db.collection('users')
+            .doc(this.$route.params['uid'])
+            .update({
+              name: this.name || "ななっしー"
+            })
+            .then(() => {
+              console.log(`User ${this.name} was updated.`);
+              this.$router.go(this.$router.currentRoute);
+            })
+            .catch(err => {
+              console.error(`Error occurd in update: ${err}`);
+            });
+        } else {
+          console.log("Error occurred on validation.");
+        }
+      },
+      requiredNotEmpty(value) {
+        const spaceRemoved = value.replace(/\s/g, '');
+        if (!spaceRemoved)
+          return "有効な表示名を入力してください．";
+        return true;
       }
     }
   }

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -96,14 +96,14 @@
           db.collection('users')
             .doc(this.$route.params['uid'])
             .update({
-              name: this.name || "ななっしー"
+              name: this.name
             })
             .then(() => {
               console.log(`User ${this.name} was updated.`);
               this.$router.go(this.$router.currentRoute);
             })
             .catch(err => {
-              console.error(`Error occurd in update: ${err}`);
+              console.error(`Error occurred in update: ${err}`);
             });
         } else {
           console.log("Error occurred on validation.");
@@ -112,7 +112,7 @@
       requiredNotEmpty(value) {
         const spaceRemoved = value.replace(/\s/g, '');
         if (!spaceRemoved)
-          return "有効な表示名を入力してください．";
+          return "Name is required.";
         return true;
       }
     }

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -59,7 +59,7 @@
       db.collection('users')
         .doc(this.$route.params['uid'])
         .get()
-        .then(function(dbUser) {
+        .then(dbUser => {
           if (dbUser.exists) {
             console.log('Successfully fetched user data');
             // console.log(JSON.stringify(dbUser.data()));
@@ -81,22 +81,18 @@
       })
     },
     watch: {
-      name: function() {
+      name() {
         console.log("name: "+this.name);
       }
     },
     methods: {
-      update: function() {
+      update() {
         console.log('update...');
-
-        if (!this.name) {
-          this.name = "ななっしー";
-        }
 
         db.collection('users')
           .doc(this.$route.params['uid'])
           .update({
-            name: this.name
+            name: this.name || "ななっしー"
           })
           .then(() => {
             console.log(`User ${this.name} was updated.`);

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -88,6 +88,11 @@
     methods: {
       update: function() {
         console.log('update...');
+
+        if (!this.name) {
+          this.name = "ななっしー";
+        }
+
         db.collection('users')
           .doc(this.$route.params['uid'])
           .update({

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -40,17 +40,17 @@
                   photoURL: currentUser.photoURL
                 })
                 .then(() => {
-                  console.log(`Event ${currentUser.displayName} was created.`);
+                  console.log('Successfully created new user:', currentUser.displayName);
                   self.$router.go(self.$router.currentRoute)
                 })
                 .catch(err => {
-                  console.error(`Error occurd in createEvent: ${err}`);
+                  console.error('Error Creating new user: ', err);
                 });
             });
           }
         })
         .catch(err => {
-          console.error(`Error fetching user data: ${err}`);
+          console.error('Error fetching user data: ', err);
         });
     },
     methods: {

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -28,7 +28,7 @@
                   color="blue"
                   :x-large="true"
                   @click="update">
-                  更新
+                  Update
                 </v-btn>
               </v-card-text>
             </v-card>

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="user">
+    <h1>User Page</h1>
+    <div v-if="user.name">
+      <img :src="user.photoURL"/><br>
+      [{{ user.name }}]<br>
+    </div>
+
+  </div>
+</template>
+
+<script>
+  import firebase from 'firebase'
+  import { db } from '@/firebase/firestore.js'
+
+  export default {
+    name: 'User',
+    data() {
+      return {
+        user: {},
+      }
+    },
+    created() {
+      let self = this
+      console.log("User Page");
+      db.collection("users")
+        .doc(this.$route.params['uid'])
+        .get()
+        .then(function(dbUser) {
+          if (dbUser.exists) {
+            console.log('Successfully fetched user data:', dbUser.data());
+            self.user = dbUser.data();
+          } else {
+            firebase.auth().onAuthStateChanged(currentUser => {
+              console.log("Creating user data...");
+              db.collection('users')
+                .doc(currentUser.uid)
+                .set({
+                  name: currentUser.displayName,
+                  photoURL: currentUser.photoURL
+                })
+                .then(() => {
+                  console.log(`Event ${currentUser.displayName} was created.`);
+                  self.$router.go(self.$router.currentRoute)
+                })
+                .catch(err => {
+                  console.error(`Error occurd in createEvent: ${err}`);
+                });
+            });
+          }
+        })
+        .catch(err => {
+          console.error(`Error fetching user data: ${err}`);
+        });
+    },
+    methods: {
+    }
+  }
+</script>
+<style>
+</style>

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -5,6 +5,9 @@
       <img :src="user.photoURL"/><br>
       [{{ user.name }}]<br>
     </div>
+    <div v-if="current">
+      <b>This is My Page</b>
+    </div>
 
   </div>
 </template>
@@ -18,42 +21,34 @@
     data() {
       return {
         user: {},
+        current: false
       }
     },
     created() {
       let self = this
-      console.log("User Page");
-      db.collection("users")
+      console.log('User Page');
+      db.collection('users')
         .doc(this.$route.params['uid'])
         .get()
         .then(function(dbUser) {
           if (dbUser.exists) {
-            console.log('Successfully fetched user data:', dbUser.data());
+            console.log('Successfully fetched user data');
+            // console.log(JSON.stringify(dbUser.data()));
             self.user = dbUser.data();
           } else {
-            firebase.auth().onAuthStateChanged(currentUser => {
-              console.log("Creating user data...");
-              db.collection('users')
-                .doc(currentUser.uid)
-                .set({
-                  name: currentUser.displayName,
-                  photoURL: currentUser.photoURL
-                })
-                .then(() => {
-                  console.log('Successfully created new user:', currentUser.displayName);
-                  self.$router.go(self.$router.currentRoute)
-                })
-                .catch(err => {
-                  console.error('Error Creating new user: ', err);
-                });
-            });
+            console.error('Error fetching user data');
+            self.user = {};
           }
         })
         .catch(err => {
           console.error('Error fetching user data: ', err);
         });
-    },
-    methods: {
+
+      firebase.auth().onAuthStateChanged(user => {
+        if (user != null && user.uid == this.$route.params['uid']) {
+          self.current = true;
+        }
+      })
     }
   }
 </script>

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -7,6 +7,34 @@
     </div>
     <div v-if="current">
       <b>This is My Page</b>
+      <v-expansion-panels>
+        <v-expansion-panel>
+          <v-expansion-panel-header>
+            <v-card-title>
+              <v-toolbar :flat="true">
+                <v-toolbar-title class="mx-autoi">
+                  Edit
+                </v-toolbar-title>
+              </v-toolbar>
+            </v-card-title>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <v-card class="pa-4 ma-6">
+              <v-card-text>
+                <v-text-field
+                  v-model="name"
+                  label="Name" />
+                <v-btn
+                  color="blue"
+                  :x-large="true"
+                  @click="update">
+                  更新
+                </v-btn>
+              </v-card-text>
+            </v-card>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
     </div>
 
   </div>
@@ -21,7 +49,8 @@
     data() {
       return {
         user: {},
-        current: false
+        current: false,
+        name: ""
       }
     },
     created() {
@@ -35,6 +64,7 @@
             console.log('Successfully fetched user data');
             // console.log(JSON.stringify(dbUser.data()));
             self.user = dbUser.data();
+            self.name = dbUser.data().name;
           } else {
             console.error('Error fetching user data');
             self.user = {};
@@ -49,6 +79,28 @@
           self.current = true;
         }
       })
+    },
+    watch: {
+      name: function() {
+        console.log("name: "+this.name);
+      }
+    },
+    methods: {
+      update: function() {
+        console.log('update...');
+        db.collection('users')
+          .doc(this.$route.params['uid'])
+          .update({
+            name: this.name
+          })
+          .then(() => {
+            console.log(`User ${this.name} was updated.`);
+            this.$router.go(this.$router.currentRoute);
+          })
+          .catch(err => {
+            console.error(`Error occurd in update: ${err}`);
+          });
+      }
     }
   }
 </script>

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -20,7 +20,7 @@
           </v-expansion-panel-header>
           <v-expansion-panel-content>
             <v-card class="pa-4 ma-6">
-              <v-form v-model="isValid">
+              <v-form v-model="isValid" @submit.prevent>
                 <v-card-text>
                   <v-text-field
                     v-model="name"


### PR DESCRIPTION
#7 
displayNameが未設定の場合困る。
↓
LT-Hubだけの表示名を設定できるようにしよう。
↓
ユーザー認証のデータにアクセスしてカラム追加できないっぽい
↓
ユーザーのDBを作っちゃえ
↓
ログイン時、dispalyNameが未設定ならユーザーページに飛ばす←デバッグ用に条件反転中
↓
ユーザーページ読み込み時、DBにユーザー情報がなかったら追加←できた
↓
ユーザーページ再読込←微妙
↓
nameを設定できるようにし、ユーザー情報を更新←まだできてない

---
ユーザー情報がDBに存在するユーザーページに飛ぶと、ユーザー情報を表示する←できた