### PR TITLE
ユーザー一覧ページ追加

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,8 @@
   <div id="app">
     <div id="nav">
       <router-link to="/">Home</router-link> |
-      <router-link to="/events">Events</router-link>
+      <router-link to="/events">Events</router-link> |
+      <router-link to="/users">Users</router-link>
     </div>
     <router-view/>
   </div>

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -12,7 +12,9 @@
 
 <script>
   export default {
-    props: ['event']
+    props: {
+      event: Object
+    }
   }
 </script>
 

--- a/src/components/GithubAuth.vue
+++ b/src/components/GithubAuth.vue
@@ -67,6 +67,7 @@ export default {
                 db.collection('users')
                   .doc(user.uid)
                   .set({
+                    uid: user.uid,
                     name: user.displayName || 'ななっしー',
                     photoURL: user.photoURL
                   })

--- a/src/components/GithubAuth.vue
+++ b/src/components/GithubAuth.vue
@@ -67,7 +67,6 @@ export default {
                 db.collection('users')
                   .doc(user.uid)
                   .set({
-                    uid: user.uid,
                     name: user.displayName || 'ななっしー',
                     photoURL: user.photoURL
                   })

--- a/src/components/NewEventForm.vue
+++ b/src/components/NewEventForm.vue
@@ -40,7 +40,7 @@
 import { db } from '@/firebase/firestore.js'
 
 export default {
-  data: function() {
+  data() {
     return {
       title: "",
       description: "",
@@ -53,33 +53,33 @@ export default {
     };
   },
   watch: {
-    title: function() {
+    title() {
       console.log("title: "+this.title);
     },
-    description: function() {
+    description() {
       console.log("description: "+this.description);
     },
-    author: function() {
+    author() {
       console.log("author: "+this.author)
     },
-    startDate: function() {
+    startDate() {
       console.log("startDate: "+this.startDate);
     },
-    startTime: function() {
+    startTime() {
       console.log("startTime: "+this.startTime);
     },
-    endDate: function() {
+    endDate() {
       console.log("endDate: "+this.endDate);
     },
-    endTime: function() {
+    endTime() {
       console.log("endTime: "+this.endTime);
     },
-    place: function() {
+    place() {
       console.log("place: "+this.place);
     },
   },
   methods: {
-    createEvent: function() {
+    createEvent() {
       console.log("Creating event...");
       db.collection('events')
         .doc()

--- a/src/components/UserItem.vue
+++ b/src/components/UserItem.vue
@@ -5,9 +5,9 @@
         <v-img
           height="200px"
           width="200px"
-          :src="user.photoURL"
+          :src="user.data.photoURL"
         />
-        <v-card-title>{{user.name}}</v-card-title>
+        <v-card-title>{{user.data.name}}</v-card-title>
       </v-container>
     </v-card>
   </div>
@@ -19,7 +19,7 @@
     methods: {
       goUserPage() {
         console.log("goUserPage");
-        this.$router.push({ name : "user", params: { uid: this.user.uid}});
+        this.$router.push({ name : "user", params: { uid: this.user.id}});
       }
     }
   }

--- a/src/components/UserItem.vue
+++ b/src/components/UserItem.vue
@@ -15,7 +15,9 @@
 
 <script>
   export default {
-    props: ['user'],
+    props: {
+      user: Object
+    },
     methods: {
       goUserPage() {
         console.log("goUserPage");

--- a/src/components/UserItem.vue
+++ b/src/components/UserItem.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="user-item">
+    <v-card class="d-inline-block mx-auto" @click="goUserPage">
+      <v-container>
+        <v-img
+          height="200px"
+          width="200px"
+          :src="user.photoURL"
+        />
+        <v-card-title>{{user.name}}</v-card-title>
+      </v-container>
+    </v-card>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: ['user'],
+    methods: {
+      goUserPage() {
+        console.log("goUserPage");
+        this.$router.push({ name : "user", params: { uid: this.user.uid}});
+      }
+    }
+  }
+</script>
+
+<style>
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Home from '@/views/Home.vue'
 import Events from '@/views/Events.vue'
+import Users from '@/views/Users.vue'
 import User from '@/views/User.vue'
 
 Vue.use(VueRouter)
@@ -16,6 +17,11 @@ const routes = [
     path: '/events',
     name: 'Events',
     component: Events
+  },
+  {
+    path: '/users',
+    name: 'Users',
+    component: Users
   },
   {
       path: '/user/:uid/',

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="users">
+    <h1>This is Users page</h1>
+    <div class="users-list">
+      <user-item
+        v-for="user in users"
+        :key="user.uid"
+        :user="user" />
+    </div>
+  </div>
+</template>
+
+<script>
+  import UserItem from '@/components/UserItem.vue'
+  import { db } from '@/firebase/firestore.js'
+
+  export default {
+    components: {
+      UserItem
+    },
+    data() {
+      return {
+        users: []
+      }
+    },
+    created() {
+      let self = this;
+      db.collection('users').get().then(function(users) {
+        users.forEach(function(user) {
+          console.log(user.data());
+          self.users.push(user.data());
+        });
+      });
+    }
+  };
+</script>
+<style>
+</style>

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -25,8 +25,8 @@
     },
     created() {
       let self = this;
-      db.collection('users').get().then(function(users) {
-        users.forEach(function(user) {
+      db.collection('users').get().then(users => {
+        users.forEach(user => {
           console.log(user.id);
           console.log(user.data());
           self.users.push({

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -4,7 +4,7 @@
     <div class="users-list">
       <user-item
         v-for="user in users"
-        :key="user.uid"
+        :key="user.id"
         :user="user" />
     </div>
   </div>
@@ -27,8 +27,12 @@
       let self = this;
       db.collection('users').get().then(function(users) {
         users.forEach(function(user) {
+          console.log(user.id);
           console.log(user.data());
-          self.users.push(user.data());
+          self.users.push({
+              id: user.id,
+              data: user.data()
+            });
         });
       });
     }


### PR DESCRIPTION
~ユーザーにuidを持たせないと、ユーザー一覧からユーザー詳細に飛べないため。~
連想配列を用いることによって解決

```
{
  id: user.id,
  data: user.data()
}
```

みたいな

![Screenshot from 2020-05-17 12-29-21](https://user-images.githubusercontent.com/20394831/82135140-1836ef80-983a-11ea-9708-cc5f88a852d5.png)
