### PR TITLE
イベント一覧のUI修正

### DIFF
--- a/src/components/CommentBoard.vue
+++ b/src/components/CommentBoard.vue
@@ -18,8 +18,8 @@
 
             <v-list-item-content>
               <v-list-item-title>{{comment.content}}</v-list-item-title>
-              <v-list-item-subtitle>
-                {{comment.createdAt.toDate().toLocaleString()}}
+              <v-list-item-subtitle v-if="comment.createdTime">
+                {{getStringFromDate(comment.createdTime.toDate())}}
               </v-list-item-subtitle>
             </v-list-item-content>
             <v-list-item-action>
@@ -63,7 +63,7 @@
     firestore() {
       return {
         // firestoreのcommentsコレクションを参照
-        comments: db.collection('talks').doc(this.talkId).collection('comments').orderBy('createdAt', 'desc')
+        comments: db.collection('talks').doc(this.talkId).collection('comments').orderBy('createdTime', 'desc')
       }
     },
     methods: {
@@ -79,6 +79,32 @@
       onScroll () {
         this.scrollInvoked++
       },
+      //日付から文字列に変換する関数
+      getStringFromDate(date) {
+        var year_str = date.getFullYear();
+        //月だけ+1すること
+        var month_str = 1 + date.getMonth();
+        var day_str = date.getDate();
+        var hour_str = date.getHours();
+        var minute_str = date.getMinutes();
+        var second_str = date.getSeconds();
+
+        month_str = ('0' + month_str).slice(-2);
+        day_str = ('0' + day_str).slice(-2);
+        hour_str = ('0' + hour_str).slice(-2);
+        minute_str = ('0' + minute_str).slice(-2);
+        second_str = ('0' + second_str).slice(-2);
+
+        var format_str = 'YYYY/MM/DD hh:mm:ss';
+        format_str = format_str.replace(/YYYY/g, year_str);
+        format_str = format_str.replace(/MM/g, month_str);
+        format_str = format_str.replace(/DD/g, day_str);
+        format_str = format_str.replace(/hh/g, hour_str);
+        format_str = format_str.replace(/mm/g, minute_str);
+        format_str = format_str.replace(/ss/g, second_str);
+
+        return format_str;
+      }
     },
   }
 </script>

--- a/src/components/CommentForm.vue
+++ b/src/components/CommentForm.vue
@@ -35,6 +35,7 @@
 </template>
 
 <script>
+  import firebase from 'firebase'
   import {db} from '@/firebase/firestore.js';
 
   export default {
@@ -62,12 +63,11 @@
       // コメント追加
       async addComment() {
         let userRef = await db.collection('users').doc(this.userId);
-        const now = new Date()
         // コメントをFirestoreへ登録
         db.collection('talks').doc(this.talkId).collection('comments').add({
           content: this.inputComment,
           userRef: userRef,
-          createdAt: now
+          createdTime: firebase.firestore.FieldValue.serverTimestamp(),
         })
         this.clear();
       },

--- a/src/components/EditEventForm.vue
+++ b/src/components/EditEventForm.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="new-item-form">
-    <v-chip class="ma-2"
+    <v-chip
+      class="ma-2"
       id="activator"
       @click:on="openDialog"
       color="blue"
@@ -154,7 +155,12 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer>
-            <v-btn color="blue darken-1" @click="updateEvent">更新</v-btn>
+            <v-btn
+              class="white--text font-weight-bold"
+              color="blue darken-1"
+              @click="updateEvent">
+              Update event
+            </v-btn>
           </v-spacer>
         </v-card-actions>
       </v-card>

--- a/src/components/EditTalkForm.vue
+++ b/src/components/EditTalkForm.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="new-talk-form">
-    <v-chip class="ma-2"
+    <v-chip
+      class="ma-2"
       id="talk-activator"
       @click:on="openDialog"
       color="blue"
@@ -46,7 +47,12 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer>
-            <v-btn color="blue darken-1" @click="updateTalk">トーク更新</v-btn>
+            <v-btn
+              class="white--text font-weight-bold"
+              color="blue darken-1"
+              @click="updateTalk">
+              Update talk
+            </v-btn>
           </v-spacer>
         </v-card-actions>
       </v-card>

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="event-item">
     <div v-if="event.id">
-      <v-card class="pa-2 ma-6" color="#CBFFD3" @click="goEventPage">
+      <v-card class="pa-2 ma-6" :color="colors[status]" @click="goEventPage">
         <v-container class="pa-0 ma-0">
           <v-row class="justify-content-between">
             <v-col class="pa-0 ma-0">

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="event-item">
     <div v-if="event.id">
-      <v-card class="pa-4 ma-6" color="#CBFFD3" @click="goEventPage">
-        <v-card-title>{{event.title}}</v-card-title>
+      <v-card class="pa-2 ma-6" color="#CBFFD3" @click="goEventPage">
+        <div class="text-left">
+          <v-chip :color="colors[status]" class="ma-0">{{messages[status]}}</v-chip>
+        </div>
+        <h1 class="text-center mb-3">{{event.title}}</h1>
         <div v-if="event.start">
           期間：{{ getStringFromDate(this.event.start.toDate()).substr(0,16) }} ~ {{ getStringFromDate(this.event.end.toDate()).substr(0,16) }}<br>
         </div>
@@ -16,6 +19,23 @@
     props: {
       event: {
         type: Object
+      },
+    },
+    data() {
+      return {
+        status: '',
+        colors: ['#FDD835','#90CAF9','#B0BEC5'],
+        messages: ['開催中！', '開催予定', '終了イベント'],
+      }
+    },
+    created() {
+      let now = new Date();
+      if (this.event.end.toDate() < now) {
+        this.status = 2;
+      } else if (this.event.start.toDate() < now && now < this.event.end.toDate()) {
+        this.status = 0;
+      } else {
+        this.status = 1;
       }
     },
     methods: {

--- a/src/components/NewEventForm.vue
+++ b/src/components/NewEventForm.vue
@@ -40,7 +40,7 @@
                     v-on="on"
                   ></v-text-field>
                 </template>
-                <v-date-picker v-model="startDate" :max="endDate">
+                <v-date-picker v-model="startDate">
                   <v-spacer></v-spacer>
                   <v-btn text color="primary" @click="modal = false">Cancel</v-btn>
                   <v-btn text color="primary" @click="$refs.dialog1.save(startDate)">OK</v-btn>

--- a/src/views/Event.vue
+++ b/src/views/Event.vue
@@ -6,6 +6,7 @@
         <div v-if="event.start">
           期間：{{ getStringFromDate(this.event.start.toDate()).substr(0,16) }} ~ {{ getStringFromDate(this.event.end.toDate()).substr(0,16) }}<br>
         </div>
+        概要：{{event.description}}<br>
         場所：{{ event.place }}<br>
         <div v-if="event.createdTime">
           作成日時：{{ getStringFromDate(event.createdTime.toDate()) }}<br>

--- a/src/views/Events.vue
+++ b/src/views/Events.vue
@@ -4,21 +4,34 @@
     <new-event-form v-if="isLogin"/>
     <div class="events-list">
       <div v-if="events.length">
-        <h1>now</h1>
-        <event-item
-          v-for="event in nowEvents"
-          :key="event.id"
-          :event="event" />
-        <h1>future</h1>
-        <event-item
-          v-for="event in futureEvents"
-          :key="event.id"
-          :event="event" />
-        <h1>past</h1>
-        <event-item
-          v-for="event in pastEvents"
-          :key="event.id"
-          :event="event" />
+        <v-sheet
+          class="pb-5"
+          color="#FFECB3">
+          <h1>now</h1>
+          <event-item
+            v-for="event in nowEvents"
+            :key="event.id"
+            :event="event" />
+        </v-sheet>
+        <v-sheet
+          class="pb-5"
+          color="#80DEEA">
+          <h1>future</h1>
+          <event-item
+            v-for="event in futureEvents"
+            :key="event.id"
+            :event="event" />
+        </v-sheet>
+        <v-sheet
+          class="pb-5"
+          color="#E0E0E0">
+          <h1>past</h1>
+          <event-item
+            v-for="event in pastEvents"
+            :key="event.id"
+            :event="event" />
+        </v-sheet>
+
       </div>
     </div>
   </div>

--- a/src/views/Events.vue
+++ b/src/views/Events.vue
@@ -4,8 +4,19 @@
     <new-event-form v-if="isLogin"/>
     <div class="events-list">
       <div v-if="events.length">
+        <h1>now</h1>
         <event-item
-          v-for="event in events"
+          v-for="event in nowEvents"
+          :key="event.id"
+          :event="event" />
+        <h1>future</h1>
+        <event-item
+          v-for="event in futureEvents"
+          :key="event.id"
+          :event="event" />
+        <h1>past</h1>
+        <event-item
+          v-for="event in pastEvents"
           :key="event.id"
           :event="event" />
       </div>
@@ -27,6 +38,9 @@
     data() {
       return {
         events: [],
+        pastEvents: [],
+        nowEvents: [],
+        futureEvents: [],
         isLogin: false
       }
     },
@@ -40,6 +54,33 @@
     firestore () {
       return {
         events: db.collection('events').orderBy('start')
+      }
+    },
+    watch: {
+      events() {
+        let pastEvents = [];
+        let nowEvents = [];
+        let futureEvents = [];
+        let now = new Date();
+
+        this.events.forEach(event =>{
+          let startTime = event.start.toDate();
+          let endTime = event.end.toDate();
+
+          if (endTime < now) {
+            pastEvents.push(event);
+          } else if (startTime < now && now < endTime) {
+            nowEvents.push(event);
+          } else {
+            futureEvents.push(event);
+          }
+        })
+        // console.log(pastEvents);
+        // console.log(nowEvents);
+        // console.log(futureEvents);
+        this.$root.$set(this, 'pastEvents', pastEvents.reverse()); //pastの中ではstartの逆順
+        this.$root.$set(this, 'nowEvents', nowEvents); //start順
+        this.$root.$set(this, 'futureEvents', futureEvents); //start順
       }
     }
   };

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -5,7 +5,9 @@
       <edit-user-form
         v-if="currentUserId == this.$route.params['uid']"
         :user="user"/>
-      <img :src="user.photoURL"/><br>
+      <v-avatar size="128">
+        <img :src="user.photoURL"/><br>
+      </v-avatar>
       <div v-if="user.createdTime">
         作成日時：{{ getStringFromDate(user.createdTime.toDate()) }}<br>
       </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39556764/84712075-b2f22d80-afa2-11ea-98a3-5b4292b0b49a.png)
+ 開催前、中、後で並びを分けた
+ シートの色で分けた
+ チップの色で分けた
+ ログインユーザーが登録済みかわかるようにした
**色とか配置をもっとこだわって、見せ方でいらないとおもったやつは除いたり、修正したりしてほしいです。Draftにします。**