### PR TITLE
参加者数、登壇者数をイベントページ、イベントアイテムにそれぞれ表示

### DIFF
--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -13,6 +13,7 @@
           </v-row>
         </v-container>
         <h1 class="text-center mb-3">{{event.title}}</h1>
+        参加者数  {{participants.length}}人（ 登壇者数  {{talks.length}}人 ）
         <div v-if="event.start">
           期間：{{ getStringFromDate(this.event.start.toDate()).substr(0,16) }} ~ {{ getStringFromDate(this.event.end.toDate()).substr(0,16) }}<br>
         </div>
@@ -36,6 +37,8 @@
         colors: ['#FDD835','#90CAF9','#B0BEC5'],
         messages: ['開催中！', '開催予定', '終了イベント'],
         isParticipated: false,
+        participants: [],
+        talks: []
       }
     },
     created() {
@@ -62,6 +65,15 @@
             });
         }
       });
+    },
+    firestore(){
+      console.log("firestore");
+      return {
+        talks: db.collection('talks')
+          .where('eventRef', '==', db.collection('events').doc(this.event.id)),
+        participants: db.collection('participants')
+          .where('eventRef', '==', db.collection('events').doc(this.event.id)),
+      }
     },
     methods: {
       goEventPage() {

--- a/src/components/EventItem.vue
+++ b/src/components/EventItem.vue
@@ -13,7 +13,7 @@
           </v-row>
         </v-container>
         <h1 class="text-center mb-3">{{event.title}}</h1>
-        参加者数  {{participants.length}}人（ 登壇者数  {{talks.length}}人 ）
+        参加者数  {{participants.length}}人（ LT数 {{talks.length}} ）
         <div v-if="event.start">
           期間：{{ getStringFromDate(this.event.start.toDate()).substr(0,16) }} ~ {{ getStringFromDate(this.event.end.toDate()).substr(0,16) }}<br>
         </div>

--- a/src/views/Event.vue
+++ b/src/views/Event.vue
@@ -132,7 +132,7 @@
       }
     },
     firestore(){
-      console.log("firestore")
+      console.log("firestore");
       return {
         event: db.collection('events').doc(this.$route.params['id']),
         talks: db.collection('talks')

--- a/src/views/Event.vue
+++ b/src/views/Event.vue
@@ -55,7 +55,7 @@
       </div>
     </div>
     <div class="talks-list">
-      登壇者数  {{talks.length}}人
+      LT数 {{talks.length}}
       <talk-item
         v-for="talk in talks"
         :key="talk.id"

--- a/src/views/Event.vue
+++ b/src/views/Event.vue
@@ -55,13 +55,14 @@
       </div>
     </div>
     <div class="talks-list">
+      登壇者数  {{talks.length}}人
       <talk-item
         v-for="talk in talks"
         :key="talk.id"
         :talk="talk"/>
     </div>
     <div v-if="participants" class="users-list">
-      参加者リスト<br>
+      参加者数  {{participants.length}}人<br />
       <participate-item
         v-for="user in participants"
         :key="user.id"


### PR DESCRIPTION
#54 
参加者数、登壇者数をイベントページ、イベントアイテムにそれぞれ表示
<img width="899" alt="スクリーンショット 2020-06-20 14 54 15" src="https://user-images.githubusercontent.com/20394831/85193778-465e9200-b306-11ea-8915-86cb54579a58.png">
<img width="889" alt="スクリーンショット 2020-06-20 14 54 27" src="https://user-images.githubusercontent.com/20394831/85193784-49598280-b306-11ea-9053-8eb72132671f.png">
<img width="876" alt="スクリーンショット 2020-06-20 14 54 38" src="https://user-images.githubusercontent.com/20394831/85193788-49f21900-b306-11ea-9290-004ce4537eaf.png">
