### PR TITLE
イベント概要：改行を含む文章の対応

### DIFF
--- a/src/components/EditEventForm.vue
+++ b/src/components/EditEventForm.vue
@@ -140,7 +140,7 @@
                   :rules="[requiredNotEmpty]"/>
               </v-flex>
               <v-flex xs12>
-                <v-text-field
+                <v-textarea
                   v-model="description"
                   label="イベント概要" />
               </v-flex>

--- a/src/components/NewEventForm.vue
+++ b/src/components/NewEventForm.vue
@@ -139,7 +139,7 @@
                   :rules="[requiredNotEmpty]"/>
               </v-flex>
               <v-flex xs12>
-                <v-text-field
+                <v-textarea
                   v-model="description"
                   label="イベント概要" />
               </v-flex>

--- a/src/views/Event.vue
+++ b/src/views/Event.vue
@@ -6,7 +6,10 @@
         <div v-if="event.start">
           期間：{{ getStringFromDate(this.event.start.toDate()).substr(0,16) }} ~ {{ getStringFromDate(this.event.end.toDate()).substr(0,16) }}<br>
         </div>
-        概要：{{event.description}}<br>
+        <div class="reline">
+          概要<br>
+          {{event.description}}<br>
+        </div>
         場所：{{ event.place }}<br>
         <div v-if="event.createdTime">
           作成日時：{{ getStringFromDate(event.createdTime.toDate()) }}<br>
@@ -242,4 +245,8 @@
 </script>
 
 <style scoped>
+  .reline {
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
 </style>

--- a/src/views/Event.vue
+++ b/src/views/Event.vue
@@ -6,10 +6,14 @@
         <div v-if="event.start">
           期間：{{ getStringFromDate(this.event.start.toDate()).substr(0,16) }} ~ {{ getStringFromDate(this.event.end.toDate()).substr(0,16) }}<br>
         </div>
-        <div class="reline">
-          概要<br>
+        概要
+        <v-card
+          v-scroll.self="onScroll"
+          class="overflow-y-auto reline"
+          max-height="400"
+          flat>
           {{event.description}}<br>
-        </div>
+        </v-card>
         場所：{{ event.place }}<br>
         <div v-if="event.createdTime">
           作成日時：{{ getStringFromDate(event.createdTime.toDate()) }}<br>
@@ -239,7 +243,10 @@
         format_str = format_str.replace(/ss/g, second_str);
 
         return format_str;
-      }
+      },
+      onScroll () {
+        this.scrollInvoked++
+      },
     }
   }
 </script>


### PR DESCRIPTION
旧）テキストフィールド
新）テキストエリア

長すぎる概要はスクロールで対応
<img width="688" alt="スクリーンショット 2020-06-20 15 11 49" src="https://user-images.githubusercontent.com/20394831/85194551-d00f5f00-b308-11ea-815f-4efbd3a99ed5.png">
<img width="526" alt="スクリーンショット 2020-06-20 15 11 57" src="https://user-images.githubusercontent.com/20394831/85194561-d30a4f80-b308-11ea-9bd2-37c4793d5087.png">
