### PR TITLE
トークアイテムに動画とスライドのアイコン追加

### DIFF
--- a/src/components/TalkItem.vue
+++ b/src/components/TalkItem.vue
@@ -6,6 +6,8 @@
         登壇者：
         <user-item-small
         :user = "talk.userRef" />
+        <v-icon v-if="talk.movieUrl != ''">mdi-youtube</v-icon>
+        <v-icon v-if="talk.slideUrl != ''">mdi-presentation</v-icon>
       </v-card-text>
     </v-card>
   </div>


### PR DESCRIPTION
トーク一覧から、どのトークが動画、スライドが貼ってあるか確認する用
<img width="799" alt="スクリーンショット 2020-06-21 12 21 40" src="https://user-images.githubusercontent.com/20394831/85215934-e9241880-b3b9-11ea-9186-1fa038c076a3.png">
<img width="809" alt="スクリーンショット 2020-06-21 12 21 28" src="https://user-images.githubusercontent.com/20394831/85215936-ea554580-b3b9-11ea-945f-fed96695a403.png">
<img width="948" alt="スクリーンショット 2020-06-21 12 21 21" src="https://user-images.githubusercontent.com/20394831/85215937-eb867280-b3b9-11ea-9266-8b61d5ed94a6.png">


