### PR TITLE
fix: #104 Delete talkIds in order when user cancel a participation

### DIFF
--- a/src/views/Event.vue
+++ b/src/views/Event.vue
@@ -252,7 +252,7 @@
           let currentUserRef = await db.collection('users').doc(this.currentUserId)
           let currentEventRef = await db.collection('events').doc(this.$route.params['id'])
           let talkIds = [];
-          await db.collection('participants')
+          db.collection('participants')
             .where('userRef', '==', currentUserRef)
             .where('eventRef', '==', currentEventRef)
             .get()
@@ -271,7 +271,7 @@
                 talkIds.push(talk.ref.id);
               })
             });
-          await currentEventRef.update({
+          currentEventRef.update({
             order: firebase.firestore.FieldValue.arrayRemove(...talkIds),
           });
           alert('ぴえん');

--- a/src/views/Event.vue
+++ b/src/views/Event.vue
@@ -251,7 +251,8 @@
           this.isParticipated = false;
           let currentUserRef = await db.collection('users').doc(this.currentUserId)
           let currentEventRef = await db.collection('events').doc(this.$route.params['id'])
-          db.collection('participants')
+          let talkIds = [];
+          await db.collection('participants')
             .where('userRef', '==', currentUserRef)
             .where('eventRef', '==', currentEventRef)
             .get()
@@ -260,15 +261,19 @@
                 participant.ref.delete();
               })
             });
-          db.collection('talks')
+          await db.collection('talks')
             .where('userRef', '==', currentUserRef)
             .where('eventRef', '==', currentEventRef)
             .get()
             .then(talks => {
               talks.forEach(talk =>{
                 talk.ref.delete();
+                talkIds.push(talk.ref.id);
               })
             });
+          await currentEventRef.update({
+            order: firebase.firestore.FieldValue.arrayRemove(...talkIds),
+          });
           alert('ぴえん');
         } else {
           alert('命拾いしましたね');


### PR DESCRIPTION
トークを作った後に、参加を取り消してもevents内のorderが消されておらず、空白のページができるなどのバグが生じていました。
したがって、参加を取り消したときに、event内のorderをしっかり消しました。