### PR TITLE
Feat/#126 manage login status

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,7 @@ import { Component, Vue } from "vue-property-decorator";
 import Header from "@/components/Header.vue";
 import { firebaseApp } from "@/firebase/firebase";
 import { Auth } from "@/firebase/auth";
+import { createUser, userExists } from "@/repository/userRepository";
 
 @Component({
   components: {
@@ -24,7 +25,9 @@ export default class App extends Vue {
   currentUid = "";
   mounted(): void {
     firebaseApp.auth().onAuthStateChanged(async (user) => {
-      console.dir(user);
+      if (user !== null && (await userExists(user.uid)) === false) {
+        await createUser(user);
+      }
       this.currentUid = Auth.currentUid();
     });
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <Header />
+    <Header :uid="currentUid" />
     <v-main fluid fill-height align-start>
       <v-container>
         <router-view />
@@ -12,13 +12,23 @@
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 import Header from "@/components/Header.vue";
+import { firebaseApp } from "@/firebase/firebase";
+import { Auth } from "@/firebase/auth";
 
 @Component({
   components: {
     Header,
   },
 })
-export default class App extends Vue {}
+export default class App extends Vue {
+  currentUid = "";
+  mounted(): void {
+    firebaseApp.auth().onAuthStateChanged(async (user) => {
+      console.dir(user);
+      this.currentUid = Auth.currentUid();
+    });
+  }
+}
 </script>
 
 <style scoped>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -50,12 +50,18 @@ import GoogleAuth from "@/components/GoogleAuth.vue";
 import Vue from "vue";
 import Component from "vue-class-component";
 
+const HeaderProps = Vue.extend({
+  props: {
+    uid: String,
+  },
+});
+
 @Component({
   components: {
     GoogleAuth,
   },
 })
-export default class Header extends Vue {
+export default class Header extends HeaderProps {
   drawer: null | boolean = null;
   items: { title: string; icon: string; to: string }[] = [
     { title: "Home", icon: "mdi-home", to: "/" },

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -40,14 +40,14 @@
           <v-icon class="ma-2">mdi-account-group</v-icon>
           Users
         </v-btn>
-        <google-auth />
+        <logout-button v-if="uid" />
+        <login-button v-else />
       </v-toolbar-items>
     </v-app-bar>
   </div>
 </template>
 
 <script lang="ts">
-import GoogleAuth from "@/components/GoogleAuth.vue";
 import LoginButton from "@/components/LoginButton.vue";
 import LogoutButton from "@/components/LogoutButton.vue";
 import Vue from "vue";
@@ -61,7 +61,6 @@ const HeaderProps = Vue.extend({
 
 @Component({
   components: {
-    GoogleAuth,
     LoginButton,
     LogoutButton,
   },

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -18,7 +18,8 @@
           </v-list-item-content>
         </v-list-item>
       </v-list>
-      <google-auth />
+      <logout-button v-if="uid" />
+      <login-button v-else />
     </v-navigation-drawer>
     <v-app-bar dark clipped-left fixed app>
       <v-app-bar-nav-icon
@@ -47,6 +48,8 @@
 
 <script lang="ts">
 import GoogleAuth from "@/components/GoogleAuth.vue";
+import LoginButton from "@/components/LoginButton.vue";
+import LogoutButton from "@/components/LogoutButton.vue";
 import Vue from "vue";
 import Component from "vue-class-component";
 
@@ -59,6 +62,8 @@ const HeaderProps = Vue.extend({
 @Component({
   components: {
     GoogleAuth,
+    LoginButton,
+    LogoutButton,
   },
 })
 export default class Header extends HeaderProps {

--- a/src/components/LoginButton.vue
+++ b/src/components/LoginButton.vue
@@ -4,6 +4,7 @@
       class="ma-2"
       style="text-transform: none"
       color="white"
+      :loading="loading"
       @click="doLogin"
       outlined
       dark
@@ -21,8 +22,13 @@ import { Auth } from "@/firebase/auth";
 
 @Component
 export default class LoginButton extends Vue {
+  loading = false;
+
   doLogin(): void {
-    Auth.login();
+    this.loading = true;
+    Auth.login().finally(() => {
+      this.loading = false;
+    });
   }
 }
 </script>

--- a/src/components/LoginButton.vue
+++ b/src/components/LoginButton.vue
@@ -17,13 +17,12 @@
 <script lang="ts">
 import Vue from "vue";
 import Component from "vue-class-component";
-import firebase from "firebase";
+import { Auth } from "@/firebase/auth";
 
 @Component
 export default class LoginButton extends Vue {
   doLogin(): void {
-    const provider = new firebase.auth.GoogleAuthProvider();
-    firebase.auth().signInWithPopup(provider);
+    Auth.login();
   }
 }
 </script>

--- a/src/components/LoginButton.vue
+++ b/src/components/LoginButton.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="google-auth">
+    <v-btn
+      class="ma-2"
+      style="text-transform: none"
+      color="white"
+      @click="doLogin"
+      outlined
+      dark
+    >
+      <v-icon dark left>mdi-login</v-icon>
+      Login
+    </v-btn>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import router from "@/router";
+import firebase from "firebase";
+
+@Component
+export default class LoginButton extends Vue {
+  doLogin(): void {
+    const provider = new firebase.auth.GoogleAuthProvider();
+    firebase.auth().signInWithPopup(provider);
+  }
+
+  doLogout(): void {
+    firebase.auth().signOut();
+    if (router.currentRoute.path !== "/") {
+      router.push("/");
+    }
+  }
+}
+</script>
+<style scoped></style>

--- a/src/components/LoginButton.vue
+++ b/src/components/LoginButton.vue
@@ -8,7 +8,7 @@
       outlined
       dark
     >
-      <v-icon dark left>mdi-login</v-icon>
+      <v-img src="@/assets/google-logo.png" left class="mr-2" />
       Login
     </v-btn>
   </div>

--- a/src/components/LoginButton.vue
+++ b/src/components/LoginButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="google-auth">
+  <div class="login-button">
     <v-btn
       class="ma-2"
       style="text-transform: none"
@@ -17,7 +17,6 @@
 <script lang="ts">
 import Vue from "vue";
 import Component from "vue-class-component";
-import router from "@/router";
 import firebase from "firebase";
 
 @Component
@@ -25,13 +24,6 @@ export default class LoginButton extends Vue {
   doLogin(): void {
     const provider = new firebase.auth.GoogleAuthProvider();
     firebase.auth().signInWithPopup(provider);
-  }
-
-  doLogout(): void {
-    firebase.auth().signOut();
-    if (router.currentRoute.path !== "/") {
-      router.push("/");
-    }
   }
 }
 </script>

--- a/src/components/LogoutButton.vue
+++ b/src/components/LogoutButton.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="google-auth">
+    <v-btn
+      class="ma-2"
+      style="text-transform: none"
+      color="white"
+      @click="doLogout"
+      outlined
+      dark
+    >
+      <v-icon dark left>mdi-logout</v-icon>
+      Logout
+    </v-btn>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import router from "@/router";
+import firebase from "firebase";
+
+@Component
+export default class LogoutButton extends Vue {
+  doLogout(): void {
+    firebase.auth().signOut();
+    if (router.currentRoute.path !== "/") {
+      router.push("/");
+    }
+  }
+}
+</script>
+<style scoped></style>

--- a/src/components/LogoutButton.vue
+++ b/src/components/LogoutButton.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="logout-button">
+    <v-avatar>
+      <img :src="this.user.photoUrl" />
+    </v-avatar>
     <v-btn
       class="ma-2"
       style="text-transform: none"
@@ -17,11 +20,19 @@
 <script lang="ts">
 import Vue from "vue";
 import Component from "vue-class-component";
+import { getUserData } from "@/repository/userRepository";
+import { User } from "@/types/user";
 import router from "@/router";
 import firebase from "firebase";
 
 @Component
 export default class LogoutButton extends Vue {
+  user?: User = {} as User;
+
+  async created(): Promise<void> {
+    this.user = await getUserData();
+  }
+
   doLogout(): void {
     firebase.auth().signOut();
     if (router.currentRoute.path !== "/") {

--- a/src/components/LogoutButton.vue
+++ b/src/components/LogoutButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="google-auth">
+  <div class="logout-button">
     <v-btn
       class="ma-2"
       style="text-transform: none"

--- a/src/components/LogoutButton.vue
+++ b/src/components/LogoutButton.vue
@@ -30,7 +30,7 @@ export default class LogoutButton extends Vue {
   user?: User = {} as User;
 
   async created(): Promise<void> {
-    this.user = await getUserData();
+    this.user = await getUserData(Auth.currentUid());
   }
 
   doLogout(): void {

--- a/src/components/LogoutButton.vue
+++ b/src/components/LogoutButton.vue
@@ -23,7 +23,7 @@ import Component from "vue-class-component";
 import { getUserData } from "@/repository/userRepository";
 import { User } from "@/types/user";
 import router from "@/router";
-import firebase from "firebase";
+import { Auth } from "@/firebase/auth";
 
 @Component
 export default class LogoutButton extends Vue {
@@ -34,7 +34,7 @@ export default class LogoutButton extends Vue {
   }
 
   doLogout(): void {
-    firebase.auth().signOut();
+    Auth.logout();
     if (router.currentRoute.path !== "/") {
       router.push("/");
     }

--- a/src/firebase/auth.ts
+++ b/src/firebase/auth.ts
@@ -10,11 +10,11 @@ export const Auth = {
     }
     return currentUser.uid;
   },
-  login(): void {
+  async login(): Promise<void> {
     const provider = new firebase.auth.GoogleAuthProvider();
-    firebaseApp.auth().signInWithPopup(provider);
+    await firebaseApp.auth().signInWithPopup(provider);
   },
-  logout(): void {
-    firebaseApp.auth().signOut();
+  async logout(): Promise<void> {
+    await firebaseApp.auth().signOut();
   },
 };

--- a/src/repository/userRepository.ts
+++ b/src/repository/userRepository.ts
@@ -1,15 +1,41 @@
 import { db } from "@/firebase/firestore";
-import { Auth } from "@/firebase/auth";
 import { User, userConverter } from "@/types/user";
 
-export async function getUserData(): Promise<User | undefined> {
+export async function userExists(id: string): Promise<boolean> {
+  const doc = await db
+    .collection("users")
+    .withConverter(userConverter)
+    .doc(id)
+    .get();
+  return doc.exists;
+}
+
+export async function getUserData(id: string): Promise<User | undefined> {
   try {
     const doc = await db
       .collection("users")
       .withConverter(userConverter)
-      .doc(Auth.currentUid())
+      .doc(id)
       .get();
     return doc.data() as User;
+  } catch (e) {
+    console.dir(e);
+  }
+}
+
+export async function createUser(user: firebase.User): Promise<void> {
+  try {
+    await db
+      .collection("users")
+      .withConverter(userConverter)
+      .doc(user.uid)
+      .set({
+        name: user.displayName || "ななっしー",
+        belong: "none",
+        photoUrl: user.photoURL,
+        createdTime: new Date(),
+        updatedTime: new Date(),
+      } as User);
   } catch (e) {
     console.dir(e);
   }


### PR DESCRIPTION
close #126 
# やったこと
今までGoogleAuthがやっていた処理をloginとlogout, Appの大きく3つの部分に分けた

#### loginコンポーネントが担うこと
- ボタンの表示
- ログイン処理を呼ぶ

#### logoutコンポーネントが担うこと
- ボタンの表示
- ログインユーザーのアイコン表示
- ログアウト処理を呼ぶ

#### Appが担うこと
- ログインユーザーの監視（onAuthStateChanged）
- 新規ログインであれば、ユーザ追加処理を呼ぶ
- ログイン状態によってコンポーネントを分岐

これらに伴ってauth, userRepositoryをそれぞれ変更した  

## 補足
このbranchは`feat/125_modify_firebase_plugin`から伸びてて

1. `feat/#126_manage_login_status`を`feat/125_modify_firebase_plugin`にmerge
2. `feat/125_modify_firebase_plugin`を`dev-v2`にmerge

しようと思ってます