### PR TITLE
Feat/#136 treat user as router view props

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <Header :currentUser="currentUser" />
     <v-main fluid fill-height align-start>
       <v-container>
-        <router-view :currentUser="currentUser" />
+        <router-view :currentUser="currentUser" :key="isLogin" />
       </v-container>
     </v-main>
   </v-app>
@@ -27,6 +27,7 @@ import { User } from "@/types/user";
 })
 export default class App extends Vue {
   currentUser = {} as User;
+  isLogin = false;
 
   created(): void {
     firebaseApp.auth().onAuthStateChanged(async (user) => {
@@ -35,8 +36,10 @@ export default class App extends Vue {
           await createUser(user);
         }
         this.currentUser = await getUserData(user.uid);
+        this.isLogin = true;
       } else {
         this.currentUser = {} as User;
+        this.isLogin = false;
       }
     });
   }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -18,7 +18,7 @@
           </v-list-item-content>
         </v-list-item>
       </v-list>
-      <logout-button v-if="uid" />
+      <logout-button v-if="currentUser.id" />
       <login-button v-else />
     </v-navigation-drawer>
     <v-app-bar dark clipped-left fixed app>
@@ -40,7 +40,7 @@
           <v-icon class="ma-2">mdi-account-group</v-icon>
           Users
         </v-btn>
-        <logout-button v-if="uid" />
+        <logout-button v-if="currentUser.id" />
         <login-button v-else />
       </v-toolbar-items>
     </v-app-bar>
@@ -50,12 +50,13 @@
 <script lang="ts">
 import LoginButton from "@/components/LoginButton.vue";
 import LogoutButton from "@/components/LogoutButton.vue";
-import Vue from "vue";
+import { User } from "@/types/user";
+import Vue, { PropType } from "vue";
 import Component from "vue-class-component";
 
 const HeaderProps = Vue.extend({
   props: {
-    uid: String,
+    currentUser: Object as PropType<User>,
   },
 });
 

--- a/src/repository/userRepository.ts
+++ b/src/repository/userRepository.ts
@@ -10,7 +10,7 @@ export async function userExists(id: string): Promise<boolean> {
   return doc.exists;
 }
 
-export async function getUserData(id: string): Promise<User | undefined> {
+export async function getUserData(id: string): Promise<User> {
   try {
     const doc = await db
       .collection("users")
@@ -19,7 +19,8 @@ export async function getUserData(id: string): Promise<User | undefined> {
       .get();
     return doc.data() as User;
   } catch (e) {
-    console.dir(e);
+    // TODO:Inform error to user by moving to 500 page or showing something like a dialog
+    throw new Error(e);
   }
 }
 


### PR DESCRIPTION
# やったこと

- getUserDataで取得に失敗すればエラーを投げる用に修正
- ログインユーザーをpropsとしてrouter-viewに渡すよう修正（未ログインの時は空のUserを渡す）
- ログイン時などにコンポーネントを再生成するために、isLoginというkeyを用意した
（これでこの先、各ページをつくるときにログイン状態が更新されたときのライフサイクルを考慮しなくて済む）


## 補足
#108 のissueが概念的に大きいと思ったので、`feat/#108_separate_events_by_its_publish_status`っていうブランチをつくって、別に細かいissueを立てました。今後何回かは`feat/#108_separate_events_by_its_publish_status`のブランチにマージしていこうと思います
