### PR TITLE
Feat/#131 display events according to user affiliation

### DIFF
--- a/src/components/events/EventListItem.vue
+++ b/src/components/events/EventListItem.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="event-item">
+    <div v-if="event.id">
+      <v-card>
+        <v-card-title> {{ event.title }}</v-card-title>
+      </v-card>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from "vue";
+import Component from "vue-class-component";
+import { Event } from "@/types/event";
+
+const EventListItemProps = Vue.extend({
+  props: {
+    event: Object as PropType<Event>,
+  },
+});
+
+@Component({})
+export default class EventListItem extends EventListItemProps {}
+</script>
+
+<style scoped></style>

--- a/src/components/events/EventListItem.vue
+++ b/src/components/events/EventListItem.vue
@@ -1,10 +1,8 @@
 <template>
   <div class="event-item">
-    <div v-if="event.id">
-      <v-card>
-        <v-card-title> {{ event.title }}</v-card-title>
-      </v-card>
-    </div>
+    <v-card>
+      <v-card-title> {{ event.title }}</v-card-title>
+    </v-card>
   </div>
 </template>
 

--- a/src/repository/eventRepository.ts
+++ b/src/repository/eventRepository.ts
@@ -1,0 +1,25 @@
+import { db } from "@/firebase/firestore";
+import { Event, eventConverter } from "@/types/event";
+import { User } from "@/types/user";
+
+export async function getEventList(user: User): Promise<Array<Event>> {
+  try {
+    if (user.belong === "proken") {
+      const collection = await db
+        .collection("events")
+        .withConverter(eventConverter)
+        .get();
+      return collection.docs.map((doc) => doc.data() as Event);
+    } else {
+      const collection = await db
+        .collection("events")
+        .withConverter(eventConverter)
+        .where("status", "==", "public")
+        .get();
+      return collection.docs.map((doc) => doc.data() as Event);
+    }
+  } catch (e) {
+    // TODO:Inform error to user by moving to 500 page or showing something like a dialog
+    throw new Error(e);
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
 import Home from "@/views/Home.vue";
+import Events from "@/views/Events.vue";
 
 Vue.use(VueRouter);
 
@@ -9,6 +10,11 @@ const routes = [
     path: "/",
     name: "home",
     component: Home,
+  },
+  {
+    path: "/events",
+    name: "events",
+    component: Events,
   },
 ];
 

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,0 +1,72 @@
+import firebase from "firebase";
+
+type EventStatus = "private" | "unlisted" | "public";
+
+export interface Event {
+  id: string;
+  title: string;
+  status: EventStatus;
+  createdTime: Date;
+  updatedTime: Date;
+}
+export interface EventDoc {
+  title: string;
+  status: EventStatus;
+  createdTime: firebase.firestore.Timestamp;
+  updatedTime: firebase.firestore.Timestamp;
+}
+
+const varidateEventType = (
+  data: firebase.firestore.DocumentData
+): data is EventDoc => {
+  if (!(data.title && typeof data.title === "string")) {
+    return false;
+  }
+  if (
+    !(
+      data.createdTime &&
+      data.createdTime instanceof firebase.firestore.Timestamp
+    )
+  ) {
+    return false;
+  }
+  if (
+    !(
+      data.updatedTime &&
+      data.updatedTime instanceof firebase.firestore.Timestamp
+    )
+  ) {
+    return false;
+  }
+  return true;
+};
+
+export const eventConverter: firebase.firestore.FirestoreDataConverter<Event> = {
+  toFirestore(event: Event): EventDoc {
+    return {
+      title: event.title,
+      createdTime: firebase.firestore.Timestamp.fromDate(event.createdTime),
+      updatedTime: firebase.firestore.Timestamp.fromDate(event.updatedTime),
+    } as EventDoc;
+  },
+
+  fromFirestore(
+    snapshot: firebase.firestore.QueryDocumentSnapshot,
+    options: firebase.firestore.SnapshotOptions
+  ): Event {
+    const data = snapshot.data(options);
+
+    if (!varidateEventType(data)) {
+      console.error(data);
+      throw new Error("Invalid data");
+    }
+
+    return {
+      id: snapshot.id,
+      title: data.title,
+      status: data.status,
+      createdTime: data.createdTime.toDate(),
+      updatedTime: data.updatedTime.toDate(),
+    } as Event;
+  },
+};

--- a/src/views/Events.vue
+++ b/src/views/Events.vue
@@ -33,7 +33,6 @@ export default class Events extends EventsProps {
 
   async created(): Promise<void> {
     await this.fetchEvents();
-    console.dir(this.events);
   }
 
   async fetchEvents(): Promise<void> {

--- a/src/views/Events.vue
+++ b/src/views/Events.vue
@@ -1,12 +1,18 @@
 <template>
   <div class="events">
     <h1>Events</h1>
+    <div class="events-list" v-if="events.length">
+      <div v-for="event in events" :key="event.id">
+        <EventListItem :event="event" />
+      </div>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import Vue, { PropType } from "vue";
 import Component from "vue-class-component";
+import EventListItem from "@/components/events/EventListItem.vue";
 import { User } from "@/types/user";
 import { Event } from "@/types/event";
 import { getEventList } from "@/repository/eventRepository";
@@ -17,7 +23,11 @@ const EventsProps = Vue.extend({
   },
 });
 
-@Component({})
+@Component({
+  components: {
+    EventListItem,
+  },
+})
 export default class Events extends EventsProps {
   events: Array<Event> = [];
 

--- a/src/views/Events.vue
+++ b/src/views/Events.vue
@@ -8,6 +8,8 @@
 import Vue, { PropType } from "vue";
 import Component from "vue-class-component";
 import { User } from "@/types/user";
+import { Event } from "@/types/event";
+import { getEventList } from "@/repository/eventRepository";
 
 const EventsProps = Vue.extend({
   props: {
@@ -17,8 +19,15 @@ const EventsProps = Vue.extend({
 
 @Component({})
 export default class Events extends EventsProps {
-  created(): void {
-    console.dir(this.currentUser);
+  events: Array<Event> = [];
+
+  async created(): Promise<void> {
+    await this.fetchEvents();
+    console.dir(this.events);
+  }
+
+  async fetchEvents(): Promise<void> {
+    this.events = await getEventList(this.currentUser);
   }
 }
 </script>

--- a/src/views/Events.vue
+++ b/src/views/Events.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="events">
+    <h1>Events</h1>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from "vue";
+import Component from "vue-class-component";
+import { User } from "@/types/user";
+
+const EventsProps = Vue.extend({
+  props: {
+    currentUser: Object as PropType<User>,
+  },
+});
+
+@Component({})
+export default class Events extends EventsProps {
+  created(): void {
+    console.dir(this.currentUser);
+  }
+}
+</script>
+<style scoped></style>


### PR DESCRIPTION
# やったこと
- Event インタフェースを追加（titleとstatusのみ、正式なものはイベント作成フォームのときに実装）
- Event リポジトリを追加
- Events, EventListItemを追加

# 結果
イベント一覧に表示されるデータが分けられる
## belongが`proken`
![image](https://user-images.githubusercontent.com/39556764/108363898-c859de80-7238-11eb-8a0f-e576d1c19c41.png)

##  belongが`none`または未ログイン
![image](https://user-images.githubusercontent.com/39556764/108363944-d4de3700-7238-11eb-8e68-022246f6ac74.png)

## 補足
- firestoreのコンソールの方でbelongを`proken`や`none`に変更とかもして動作確認してほしい